### PR TITLE
[bob]rpcpassの宣言を他と同じように変更した

### DIFF
--- a/src/bob/main.go
+++ b/src/bob/main.go
@@ -38,7 +38,7 @@ const interval = 3 * time.Second
 
 var rpcurl string = "http://127.0.0.1:10010"
 var rpcuser string = "user"
-var rpcpass = "pass"
+var rpcpass string = "pass"
 
 var rpcClient *rpc.Rpc
 


### PR DESCRIPTION
bobのソースコードで、変数宣言rpcpassの方法を
他と同じように、型stringを付与した
