### PR TITLE
[democonf]pathの取得方法変更

### DIFF
--- a/src/democonf/democonf.go
+++ b/src/democonf/democonf.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"path/filepath"
 )
 
 type DemoConf struct {
@@ -19,7 +20,7 @@ type DemoConf struct {
 func NewDemoConf(section string) *DemoConf {
 	conf := new(DemoConf)
 	conf.logger = log.New(os.Stdout, "DemoConf:", log.LstdFlags)
-	dir, _ := os.Getwd()
+	dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 	file, err := os.Open(dir + "/democonf.json")
 	if err != nil {
 		conf.logger.Println("os#Open error", err)


### PR DESCRIPTION
バイナリのフルパス取得方法が間違っていた

os.Getwd()
↑これを↓に変更
filepath.Abs(filepath.Dir(os.Args[0]))

バイナリと同じフォルダで実行すれば問題ないが、
パスを指定して実行すると、confが取得できない
例：
./dave　OK
demo/dave NG

htmlを指定しているのも同じロジックなので、
alice,charlie,daveも同様に修正する方が良いと思う
