### PR TITLE
Cleanup

### DIFF
--- a/src/alice/main.go
+++ b/src/alice/main.go
@@ -162,7 +162,7 @@ func doOffer(reqParam url.Values, reqBody string) ([]byte, error) {
 	}
 
 	if len(tmp) != 1 {
-		err := fmt.Errorf("offer must single record but has:%d", len(tmp))
+		err := fmt.Errorf("offer must be a single record but has:%d", len(tmp))
 		logger.Println("error:", err)
 		return nil, err
 	}
@@ -678,11 +678,11 @@ func initialize() {
 	elementsTxOption = conf.GetString("txoption", defaultTxOption)
 	rpc.SetUtxoLockDuration(time.Duration(int64(conf.GetNumber("timeout", defaultTimeout))) * time.Second)
 
-	exLocalAddr := exchangerConf.GetString("laddr", defaultExchLocalAddr)
-	exchangeRateURL = "http://127.0.0.1" + exLocalAddr + "/getexchangerate/"
-	exchangeOfferWBURL = "http://127.0.0.1" + exLocalAddr + "/getexchangeofferwb/"
-	exchangeOfferURL = "http://127.0.0.1" + exLocalAddr + "/getexchangeoffer/"
-	exchangeSubmitURL = "http://127.0.0.1" + exLocalAddr + "/submitexchange/"
+	exLocalAddr := "http://127.0.0.1" + exchangerConf.GetString("laddr", defaultExchLocalAddr)
+	exchangeRateURL = exLocalAddr + "/getexchangerate/"
+	exchangeOfferWBURL = exLocalAddr + "/getexchangeofferwb/"
+	exchangeOfferURL = exLocalAddr + "/getexchangeoffer/"
+	exchangeSubmitURL = exLocalAddr + "/submitexchange/"
 }
 
 func main() {

--- a/src/charlie/main.go
+++ b/src/charlie/main.go
@@ -74,7 +74,7 @@ func doGetRate(reqParam url.Values, reqBody string) ([]byte, error) {
 	}
 	request := rateRequest.Request
 	if len(request) != 1 {
-		err = fmt.Errorf("request must single record, but has :%d", len(request))
+		err = fmt.Errorf("request must be a single record but has:%d", len(request))
 		logger.Println("error:", err)
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func doOfferWithBlinding(reqParam url.Values, reqBody string) ([]byte, error) {
 	}
 	request := offerRequest.Request
 	if len(request) != 1 {
-		err = fmt.Errorf("request must single record but has :%d", len(request))
+		err = fmt.Errorf("request must be a single record but has:%d", len(request))
 		logger.Println("error:", err)
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func doOffer(reqParam url.Values, reqBody string) ([]byte, error) {
 	}
 	request := offerRequest.Request
 	if len(request) != 1 {
-		err = fmt.Errorf("request must single record but has :%d", len(request))
+		err = fmt.Errorf("request must be a single record but has:%d", len(request))
 		logger.Println("error:", err)
 		return nil, err
 	}

--- a/src/rpc/helper.go
+++ b/src/rpc/helper.go
@@ -41,6 +41,16 @@ func (ul UnspentList) Less(i, j int) bool {
 	return (*ul[i]).Confirmations < (*ul[j]).Confirmations
 }
 
+func (ul UnspentList) GetAmount() int64 {
+	var totalAmount int64 = 0
+
+	for _, u := range ul {
+		totalAmount += u.Amount
+	}
+
+	return totalAmount
+}
+
 func getLockingKey(txid string, vout int64) string {
 	return fmt.Sprintf("%s:%d", txid, vout)
 }
@@ -140,14 +150,12 @@ func (rpc *Rpc) SearchUnspent(lockList LockList, requestAsset string, requestAmo
 		if requestAmount < totalAmount {
 			break
 		}
-		/*
-			if blinding && (u.AssetCommitment == "") {
-				continue
-			}
-			if !blinding && (u.AssetCommitment != "") {
-				continue
-			}
-		*/
+		if blinding && (u.AssetCommitment == "") {
+			continue
+		}
+		if !blinding && (u.AssetCommitment != "") {
+			continue
+		}
 		if !(u.Spendable || u.Solvable) {
 			continue
 		}
@@ -185,14 +193,12 @@ func (rpc *Rpc) SearchMinimalUnspent(lockList LockList, requestAsset string, bli
 	var start int = 0
 	var found bool = false
 	for i, u := range ul {
-		/*
-			if blinding && (u.AssetCommitment == "") {
-				continue
-			}
-			if !blinding && (u.AssetCommitment != "") {
-				continue
-			}
-		*/
+		if blinding && (u.AssetCommitment == "") {
+			continue
+		}
+		if !blinding && (u.AssetCommitment != "") {
+			continue
+		}
 		if !(u.Spendable || u.Solvable) {
 			continue
 		}


### PR DESCRIPTION
refactoring alice, charlie.

- common
  uncomment check UTXO-AssetCommitment on SearchUnspent/SearchMinimalUnspent(lib/http)
  commonize GetID.(lib/http)
  use json.Unmarshal with struct for request parse (charlie.doXXX)
  rename Listen to LocalAddr (alice/charlie)
  move StartCyclicProc/WaitStopSignal to lib/http
  move func(GetAmount/getLockingKey) to rcp/helper
  use rpc.SetUtxoLockDuration
  delete unnecessary comments, flags, log
- logger
  output handler-name when its called and returned.
  delete unnecessary fmt.Sprintf in logger.Println.
- error
  use fmt.Errorf instead of errors.New
