### PR TITLE
[shell]開始シェルと終了シェルを修正

### DIFF
--- a/start_demo.sh
+++ b/start_demo.sh
@@ -16,18 +16,12 @@ DEMOD=$PWD/demo
 ELDAE=elementsd
 ELCLI=elements-cli
 ELTX=elements-tx
-echo "ELCLI=$ELCLI" >> ./demo.tmp
 
 ## cleanup previous data
-#for i in alice bob charlie dave fred; do
-#    ${ELCLI} -datadir=${DEMOD}/data/${i} stop 2>/dev/null
-#    pkill -SIGINT $i
-#done
-#pkill ${ELDAE}
-#sleep 2
 if [ -e ./demo.tmp ]; then
     ./stop_demo.sh
 fi
+echo "ELCLI=$ELCLI" >> ./demo.tmp
 
 ## cleanup previous data
 rm -rf ${DEMOD}/data
@@ -95,8 +89,8 @@ assetdir=$AIRSKY:AIRSKY
 assetdir=$MELON:MELON
 assetdir=$MONECRE:MONECRE
 EOF
-    ${ELDAE} -datadir=${DEMOD}/data/$i
-    echo "${i}_dae=`ps xw | grep -- -datadir=${DEMOD}/data/$i  | grep -v grep | awk '{print $1}'`" >> ./demo.tmp
+    ${ELDAE} -datadir=${DEMOD}/data/$i &
+    echo "${i}_dae=$!" >> ./demo.tmp
 done
 
 LDW=1

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -16,14 +16,18 @@ DEMOD=$PWD/demo
 ELDAE=elementsd
 ELCLI=elements-cli
 ELTX=elements-tx
+echo "ELCLI=$ELCLI" >> ./demo.tmp
 
 ## cleanup previous data
-for i in alice bob charlie dave fred; do
-    ${ELCLI} -datadir=${DEMOD}/data/${i} stop 2>/dev/null
-    pkill -SIGINT $i
-done
-pkill ${ELDAE}
-sleep 2
+#for i in alice bob charlie dave fred; do
+#    ${ELCLI} -datadir=${DEMOD}/data/${i} stop 2>/dev/null
+#    pkill -SIGINT $i
+#done
+#pkill ${ELDAE}
+#sleep 2
+if [ -e ./demo.tmp ]; then
+    ./stop_demo.sh
+fi
 
 ## cleanup previous data
 rm -rf ${DEMOD}/data
@@ -51,6 +55,7 @@ EOF
     alias ${i}-dae="${ELDAE} -datadir=${DEMOD}/data/$i"
     alias ${i}-tx="${ELTX}"
     alias ${i}="${ELCLI} -datadir=${DEMOD}/data/$i"
+    echo "${i}_dir=\"-datadir=${DEMOD}/data/$i\"" >> ./demo.tmp
 done
 
 fred-dae
@@ -91,6 +96,7 @@ assetdir=$MELON:MELON
 assetdir=$MONECRE:MONECRE
 EOF
     ${ELDAE} -datadir=${DEMOD}/data/$i
+    echo "${i}_dae=`ps xw | grep -- -datadir=${DEMOD}/data/$i  | grep -v grep | awk '{print $1}'`" >> ./demo.tmp
 done
 
 LDW=1
@@ -154,6 +160,7 @@ charlie getwalletinfo
 cd ${DEMOD}
 for i in alice bob charlie dave fred; do
     ./$i &
+    echo "${i}_pid=$!" >> ../demo.tmp
 done
 
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/stop_demo.sh
+++ b/stop_demo.sh
@@ -1,11 +1,53 @@
 #!/bin/bash
 
-# Stop the demo. This script is definitely not the way to do this in a production environment.
-# Note that any running elementsd processes WILL be killed unless owned by a different user!
 
-pkill bob
-pkill dave
-pkill charlie
-pkill alice
-pkill fred
-pkill -9 elementsd
+if [ -e ./demo.tmp ]; then
+
+    source ./demo.tmp
+
+    gopids=( $dave_pid $alice_pid $charlie_pid $fred_pid $bob_pid )
+    for pid in "${gopids[@]}"; do
+        if [ -e "/proc/$pid" ]; then
+            echo "kill -SIGINT $pid"
+            kill -SIGINT $pid
+        fi
+    done
+    sleep 3
+    for pid in "${gopids[@]}"; do
+        if [ -e "/proc/$pid" ]; then
+            echo "kill -9 $pid"
+            kill -9 $pid
+        fi
+    done
+
+    dirs=( $dave_dir $alice_dir $charlie_dir $fred_dir $bob_dir )
+    for dir in "${dirs[@]}"; do
+        echo "$ELCLI $dir stop"
+        $ELCLI $dir stop
+    done
+    sleep 3
+    pids=( $dave_dae $alice_dae $charlie_dae $fred_dae $bob_dae )
+    for pid in "${pids[@]}"; do
+        if [ -e "/proc/$pid" ]; then
+            echo "kill -9 $pid"
+            kill -9 $pid
+        fi
+    done
+
+    rm -f ./demo.tmp
+
+else
+
+    echo "kill processes"
+
+    # Stop the demo. This script is definitely not the way to do this in a production environment.
+    # Note that any running elementsd processes WILL be killed unless owned by a different user!
+
+    pkill bob
+    pkill dave
+    pkill charlie
+    pkill alice
+    pkill fred
+    pkill -9 elementsd
+
+fi


### PR DESCRIPTION
終了シェルを実行すると、ユーザが実行しているelementsdを全て終了してしまうので、
前回起動した情報をdemo.tmpに保存して、対象のみ終了するように変更した

go言語の方も、SIGINTを投げることで正常に終了するように変更

それぞれ３秒まってもプロセスが残る場合は強制終了とした