### PR TITLE
[shell]終了シェルのmacos対応、異常時処理の改善

### DIFF
--- a/start_demo.sh
+++ b/start_demo.sh
@@ -40,7 +40,7 @@ port=$((10001 + $PORT))
 
 connect=localhost:$((10001 + $(($PORT + 10)) % 50))
 regtest=1
-daemon=1
+daemon=0
 listen=1
 txindex=1
 keypool=10
@@ -52,7 +52,7 @@ EOF
     echo "${i}_dir=\"-datadir=${DEMOD}/data/$i\"" >> ./demo.tmp
 done
 
-fred-dae
+fred-dae &
 
 LDW=1
 while [ "${LDW}" = "1" ]

--- a/stop_demo.sh
+++ b/stop_demo.sh
@@ -7,14 +7,14 @@ if [ -e ./demo.tmp ]; then
 
     gopids=( $dave_pid $alice_pid $charlie_pid $fred_pid $bob_pid )
     for pid in "${gopids[@]}"; do
-        if [ -e "/proc/$pid" ]; then
+        if ps -p $pid > /dev/null ; then
             echo "kill -SIGINT $pid"
             kill -SIGINT $pid
         fi
     done
     sleep 3
     for pid in "${gopids[@]}"; do
-        if [ -e "/proc/$pid" ]; then
+        if ps -p $pid > /dev/null ; then
             echo "kill -9 $pid"
             kill -9 $pid
         fi
@@ -28,7 +28,7 @@ if [ -e ./demo.tmp ]; then
     sleep 3
     pids=( $dave_dae $alice_dae $charlie_dae $fred_dae $bob_dae )
     for pid in "${pids[@]}"; do
-        if [ -e "/proc/$pid" ]; then
+        if ps -p $pid > /dev/null ; then
             echo "kill -9 $pid"
             kill -9 $pid
         fi


### PR DESCRIPTION
・macosには/procが存在しないため、終了シェルのプロセス有無判定に ps コマンドを利用する。
・開始シェルが生成するelementsd.confのdaemonフラグをオフにすることで、elements-cliからelementsdを停止できなかった場合にもelementsdを終了可能とする。