### PR TITLE
fix SearchMinimalUnspent() returns a utxo which have maximal amounts.

### DIFF
--- a/src/rpc/helper.go
+++ b/src/rpc/helper.go
@@ -212,6 +212,7 @@ func (rpc *Rpc) SearchMinimalUnspent(lockList LockList, requestAsset string, bli
 
 		start = i
 		found = true
+		break
 	}
 	if !found {
 		err := fmt.Errorf("no utxo [%s]", requestAsset)


### PR DESCRIPTION
add 'break' after finding a 1st candidate utxo.